### PR TITLE
refactor(build): Use venv for dependencies in Dockerfile

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -15,11 +15,13 @@ WORKDIR /app
 # Copy dependency files first (better caching)
 COPY pyproject.toml poetry.lock ./
 
-# Export dependencies to requirements.txt for faster installation
-RUN pip install poetry poetry-plugin-export && \
+# Install poetry and export dependencies
+RUN pip install --no-cache-dir poetry poetry-plugin-export && \
     poetry export -f requirements.txt --output requirements.txt --without-hashes
 
-# Install dependencies using pip (faster than poetry)
+# Install dependencies in a virtual environment
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Runtime stage
@@ -35,9 +37,9 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-# Copy installed packages from builder
-COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
+# Copy virtual environment from builder
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy application code
 COPY --chown=appuser:appuser modules ./modules


### PR DESCRIPTION
This pull request updates the `Dockerfile.api` to enhance dependency management and runtime configuration. The changes focus on transitioning to a virtual environment for Python dependencies and improving caching and installation efficiency.

Dependency management improvements:

* [`Dockerfile.api`](diffhunk://#diff-bcecc648a0fede4c0ce18d730c5d88b4007fa0144bbb1b93d7ab7ac16a7da1eeL18-R24): Updated the dependency installation process to use the `--no-cache-dir` option with `pip` for better caching and added the creation of a Python virtual environment (`venv`). The virtual environment path is now included in the `PATH` environment variable.

Runtime configuration updates:

* [`Dockerfile.api`](diffhunk://#diff-bcecc648a0fede4c0ce18d730c5d88b4007fa0144bbb1b93d7ab7ac16a7da1eeL38-R42): Modified the runtime stage to copy the virtual environment (`/opt/venv`) instead of individual Python site-packages and binaries, ensuring consistency and simplifying runtime setup. Updated the `PATH` environment variable accordingly.Refactor Dockerfile to use a virtual environment for managing dependencies. This improves isolation and avoids conflicts with system-level packages. The changes include installing poetry and exporting dependencies, creating a virtual environment, and copying the virtual environment to the runtime stage.