### PR TITLE
Add daily LeetCode bot

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -26,3 +26,8 @@ CLIENT_SECRET=  # for discord oauth2
 CLERK_SECRET_KEY=  # for clerk authentication
 CLERK_AUTHORIZED_PARTIES=  # comma-separated list of authorized origins (e.g., https://thesoda.io,https://localhost:5173)
 SENTRY_DSN=  # for error tracking and logging (e.g., https://...@o...ingest.us.sentry.io/...)
+
+# LeetCode daily bot
+LEETCODE_CHANNEL_ID=  # channel ID where daily problems are posted
+LEETCODE_ROLE_PING=  # (optional) role ID to ping with each daily post
+LEETCODE_DAILY_TIME=09:00  # time to post daily question (HH:MM, uses TIMEZONE above)

--- a/modules/bot/discord_modules/cogs/LeetCodeCog.py
+++ b/modules/bot/discord_modules/cogs/LeetCodeCog.py
@@ -96,11 +96,11 @@ class LeetCodeCog(commands.Cog):
             try:
                 channel = await self.bot.fetch_channel(self.channel_id)
             except Exception:
-                logger.error(f"LeetCode channel {self.channel_id} not found")
+                logger.error(f"LeetCode channel {self.channel_id} not found", exc_info=True)
                 return
 
         if not callable(getattr(channel, "send", None)):
-            logger.error(f"LeetCode channel {self.channel_id} is not a text-capable channel")
+            logger.error(f"LeetCode channel {self.channel_id} does not support sending messages")
             return
 
         try:

--- a/modules/bot/discord_modules/cogs/LeetCodeCog.py
+++ b/modules/bot/discord_modules/cogs/LeetCodeCog.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Annotated
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import discord
@@ -41,7 +42,9 @@ def build_question_embed(question: dict, is_daily: bool = False) -> discord.Embe
 
 
 class LeetCodeCog(commands.Cog):
-    def __init__(self, bot: commands.Bot, channel_id: int | None, role_ping: int | None, daily_time: str, timezone: str):
+    def __init__(
+        self, bot: commands.Bot, channel_id: int | None, role_ping: int | None, daily_time: str, timezone: str
+    ):
         self.bot = bot
         self.channel_id = channel_id
         self.role_ping = role_ping
@@ -69,7 +72,11 @@ class LeetCodeCog(commands.Cog):
             logger.warning(f"Invalid LEETCODE_DAILY_TIME '{self.daily_time}', defaulting to 09:00")
             hour, minute = 9, 0
 
-        post_time = datetime.time(hour=hour, minute=minute, tzinfo=tz)
+        try:
+            post_time = datetime.time(hour=hour, minute=minute, tzinfo=tz)
+        except ValueError:
+            logger.warning(f"Invalid LEETCODE_DAILY_TIME '{self.daily_time}', defaulting to 09:00")
+            post_time = datetime.time(hour=9, minute=0, tzinfo=tz)
         self.post_daily.change_interval(time=post_time)
         self.post_daily.start()
         self._daily_task_started = True
@@ -85,8 +92,15 @@ class LeetCodeCog(commands.Cog):
             return
 
         channel = self.bot.get_channel(self.channel_id)
-        if not channel:
-            logger.error(f"LeetCode channel {self.channel_id} not found")
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(self.channel_id)
+            except Exception:
+                logger.error(f"LeetCode channel {self.channel_id} not found")
+                return
+
+        if not callable(getattr(channel, "send", None)):
+            logger.error(f"LeetCode channel {self.channel_id} is not a text-capable channel")
             return
 
         try:
@@ -114,13 +128,16 @@ class LeetCodeCog(commands.Cog):
     async def random(
         self,
         ctx: discord.ApplicationContext,
-        difficulty: discord.Option(
-            str,
-            description="Filter by difficulty",
-            choices=["Easy", "Medium", "Hard"],
-            required=False,
-            default=None,
-        ),
+        difficulty: Annotated[
+            str | None,
+            discord.Option(
+                str,
+                description="Filter by difficulty",
+                choices=["Easy", "Medium", "Hard"],
+                required=False,
+                default=None,
+            ),
+        ] = None,
     ):
         await ctx.defer()
         try:

--- a/modules/bot/discord_modules/cogs/LeetCodeCog.py
+++ b/modules/bot/discord_modules/cogs/LeetCodeCog.py
@@ -1,0 +1,132 @@
+import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import discord
+from discord.ext import commands, tasks
+
+from modules.bot.discord_modules.utils.leetcode import fetch_daily_question, fetch_random_question
+from modules.utils.logging_config import get_logger
+
+logger = get_logger("bot.leetcodecog")
+
+DIFFICULTY_COLORS = {
+    "Easy": 0x00B8A3,
+    "Medium": 0xFFC01E,
+    "Hard": 0xFF375F,
+}
+
+
+def build_question_embed(question: dict, is_daily: bool = False) -> discord.Embed:
+    url = f"https://leetcode.com/problems/{question['titleSlug']}/"
+    tags = " ".join(f"`{t['name']}`" for t in question.get("topicTags", [])) or "None"
+    color = DIFFICULTY_COLORS.get(question.get("difficulty", ""), 0x5865F2)
+    title_prefix = "Daily Challenge" if is_daily else "Random Problem"
+
+    embed = discord.Embed(
+        title=f"{'📅' if is_daily else '🎲'} {title_prefix} — {question['title']}",
+        url=url,
+        color=color,
+    )
+    embed.add_field(name="Difficulty", value=question.get("difficulty", "Unknown"), inline=True)
+    embed.add_field(name="Acceptance", value=f"{question.get('acRate', 0):.1f}%", inline=True)
+    embed.add_field(name="ID", value=f"#{question.get('frontendQuestionId', '?')}", inline=True)
+    embed.add_field(name="Topics", value=tags, inline=False)
+    embed.set_footer(text="Good luck! React with ✅ when you solve it.")
+    embed.timestamp = discord.utils.utcnow()
+
+    if question.get("paidOnly"):
+        embed.description = "⚠️ This is a **premium** problem (LeetCode Plus required)."
+
+    return embed
+
+
+class LeetCodeCog(commands.Cog):
+    def __init__(self, bot: commands.Bot, channel_id: int | None, role_ping: int | None, daily_time: str, timezone: str):
+        self.bot = bot
+        self.channel_id = channel_id
+        self.role_ping = role_ping
+        self.daily_time = daily_time
+        self.timezone = timezone
+        self._daily_task_started = False
+        logger.info(f"LeetCodeCog initialized (channel={channel_id}, time={daily_time}, tz={timezone})")
+
+    def cog_unload(self):
+        self.post_daily.cancel()
+
+    async def _start_daily_task(self):
+        if self._daily_task_started or not self.channel_id:
+            return
+
+        try:
+            tz = ZoneInfo(self.timezone)
+        except ZoneInfoNotFoundError:
+            logger.warning(f"Unknown timezone '{self.timezone}', falling back to UTC")
+            tz = ZoneInfo("UTC")
+
+        try:
+            hour, minute = (int(x) for x in self.daily_time.split(":")[:2])
+        except (ValueError, AttributeError):
+            logger.warning(f"Invalid LEETCODE_DAILY_TIME '{self.daily_time}', defaulting to 09:00")
+            hour, minute = 9, 0
+
+        post_time = datetime.time(hour=hour, minute=minute, tzinfo=tz)
+        self.post_daily.change_interval(time=post_time)
+        self.post_daily.start()
+        self._daily_task_started = True
+        logger.info(f"Daily LeetCode task scheduled at {post_time}")
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        await self._start_daily_task()
+
+    @tasks.loop(hours=24)
+    async def post_daily(self):
+        if not self.channel_id:
+            return
+
+        channel = self.bot.get_channel(self.channel_id)
+        if not channel:
+            logger.error(f"LeetCode channel {self.channel_id} not found")
+            return
+
+        try:
+            question = await fetch_daily_question()
+            embed = build_question_embed(question, is_daily=True)
+            content = f"<@&{self.role_ping}>" if self.role_ping else None
+            msg = await channel.send(content=content, embed=embed)
+            await msg.add_reaction("✅")
+            logger.info(f"Posted daily LeetCode: {question['title']}")
+        except Exception:
+            logger.error("Failed to post daily LeetCode question", exc_info=True)
+
+    @discord.slash_command(name="daily", description="Get today's LeetCode daily challenge")
+    async def daily(self, ctx: discord.ApplicationContext):
+        await ctx.defer()
+        try:
+            question = await fetch_daily_question()
+            embed = build_question_embed(question, is_daily=True)
+            await ctx.followup.send(embed=embed)
+        except Exception:
+            logger.error("Failed to fetch daily question", exc_info=True)
+            await ctx.followup.send("❌ Failed to fetch the daily challenge. Try again later.")
+
+    @discord.slash_command(name="random", description="Get a random LeetCode problem")
+    async def random(
+        self,
+        ctx: discord.ApplicationContext,
+        difficulty: discord.Option(
+            str,
+            description="Filter by difficulty",
+            choices=["Easy", "Medium", "Hard"],
+            required=False,
+            default=None,
+        ),
+    ):
+        await ctx.defer()
+        try:
+            question = await fetch_random_question(difficulty)
+            embed = build_question_embed(question, is_daily=False)
+            await ctx.followup.send(embed=embed)
+        except Exception:
+            logger.error("Failed to fetch random question", exc_info=True)
+            await ctx.followup.send("❌ Failed to fetch a random problem. Try again later.")

--- a/modules/bot/discord_modules/utils/leetcode.py
+++ b/modules/bot/discord_modules/utils/leetcode.py
@@ -13,6 +13,9 @@ HEADERS = {
 }
 
 
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=10)
+
+
 async def fetch_daily_question() -> dict:
     query = """
     query questionOfToday {
@@ -34,12 +37,17 @@ async def fetch_daily_question() -> dict:
       }
     }
     """
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(timeout=REQUEST_TIMEOUT) as session:
         async with session.post(LEETCODE_GRAPHQL, json={"query": query}, headers=HEADERS) as resp:
             if resp.status != 200:
                 raise RuntimeError(f"LeetCode API error: {resp.status}")
             data = await resp.json()
-    return data["data"]["activeDailyCodingChallengeQuestion"]["question"]
+    if "errors" in data:
+        raise RuntimeError(f"LeetCode GraphQL errors: {data['errors']}")
+    try:
+        return data["data"]["activeDailyCodingChallengeQuestion"]["question"]
+    except (KeyError, TypeError) as exc:
+        raise RuntimeError(f"Unexpected LeetCode API response: {data}") from exc
 
 
 async def fetch_random_question(difficulty: str | None = None) -> dict:
@@ -71,7 +79,7 @@ async def fetch_random_question(difficulty: str | None = None) -> dict:
     if difficulty:
         filters["difficulty"] = difficulty.upper()
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(timeout=REQUEST_TIMEOUT) as session:
         # First request: get total count
         async with session.post(
             LEETCODE_GRAPHQL,
@@ -90,7 +98,12 @@ async def fetch_random_question(difficulty: str | None = None) -> dict:
                 raise RuntimeError(f"LeetCode API error: {resp.status}")
             count_data = await resp.json()
 
-        total = count_data["data"]["problemsetQuestionList"]["total"]
+        if "errors" in count_data:
+            raise RuntimeError(f"LeetCode GraphQL errors: {count_data['errors']}")
+        try:
+            total = count_data["data"]["problemsetQuestionList"]["total"]
+        except (KeyError, TypeError) as exc:
+            raise RuntimeError(f"Unexpected LeetCode API response: {count_data}") from exc
         random_skip = random.randint(0, total - 1)
 
         # Second request: fetch the random problem
@@ -111,4 +124,9 @@ async def fetch_random_question(difficulty: str | None = None) -> dict:
                 raise RuntimeError(f"LeetCode API error: {resp.status}")
             data = await resp.json()
 
-    return data["data"]["problemsetQuestionList"]["questions"][0]
+    if "errors" in data:
+        raise RuntimeError(f"LeetCode GraphQL errors: {data['errors']}")
+    try:
+        return data["data"]["problemsetQuestionList"]["questions"][0]
+    except (KeyError, TypeError, IndexError) as exc:
+        raise RuntimeError(f"Unexpected LeetCode API response: {data}") from exc

--- a/modules/bot/discord_modules/utils/leetcode.py
+++ b/modules/bot/discord_modules/utils/leetcode.py
@@ -1,4 +1,4 @@
-import random
+import secrets
 
 import aiohttp
 
@@ -104,7 +104,7 @@ async def fetch_random_question(difficulty: str | None = None) -> dict:
             total = count_data["data"]["problemsetQuestionList"]["total"]
         except (KeyError, TypeError) as exc:
             raise RuntimeError(f"Unexpected LeetCode API response: {count_data}") from exc
-        random_skip = random.randint(0, total - 1)
+        random_skip = secrets.randbelow(total)
 
         # Second request: fetch the random problem
         async with session.post(

--- a/modules/bot/discord_modules/utils/leetcode.py
+++ b/modules/bot/discord_modules/utils/leetcode.py
@@ -1,0 +1,114 @@
+import random
+
+import aiohttp
+
+from modules.utils.logging_config import get_logger
+
+logger = get_logger("bot.leetcode")
+
+LEETCODE_GRAPHQL = "https://leetcode.com/graphql"
+HEADERS = {
+    "Content-Type": "application/json",
+    "Referer": "https://leetcode.com",
+}
+
+
+async def fetch_daily_question() -> dict:
+    query = """
+    query questionOfToday {
+      activeDailyCodingChallengeQuestion {
+        date
+        link
+        question {
+          frontendQuestionId: questionFrontendId
+          title
+          titleSlug
+          difficulty
+          acRate
+          paidOnly: isPaidOnly
+          topicTags {
+            name
+            slug
+          }
+        }
+      }
+    }
+    """
+    async with aiohttp.ClientSession() as session:
+        async with session.post(LEETCODE_GRAPHQL, json={"query": query}, headers=HEADERS) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"LeetCode API error: {resp.status}")
+            data = await resp.json()
+    return data["data"]["activeDailyCodingChallengeQuestion"]["question"]
+
+
+async def fetch_random_question(difficulty: str | None = None) -> dict:
+    query = """
+    query problemsetQuestionList($categorySlug: String, $limit: Int, $skip: Int, $filters: QuestionListFilterInput) {
+      problemsetQuestionList: questionList(
+        categorySlug: $categorySlug
+        limit: $limit
+        skip: $skip
+        filters: $filters
+      ) {
+        total: totalNum
+        questions: data {
+          frontendQuestionId: questionFrontendId
+          title
+          titleSlug
+          difficulty
+          acRate
+          paidOnly: isPaidOnly
+          topicTags {
+            name
+            slug
+          }
+        }
+      }
+    }
+    """
+    filters = {}
+    if difficulty:
+        filters["difficulty"] = difficulty.upper()
+
+    async with aiohttp.ClientSession() as session:
+        # First request: get total count
+        async with session.post(
+            LEETCODE_GRAPHQL,
+            json={
+                "query": query,
+                "variables": {
+                    "categorySlug": "all-code-essentials",
+                    "limit": 1,
+                    "skip": 0,
+                    "filters": filters,
+                },
+            },
+            headers=HEADERS,
+        ) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"LeetCode API error: {resp.status}")
+            count_data = await resp.json()
+
+        total = count_data["data"]["problemsetQuestionList"]["total"]
+        random_skip = random.randint(0, total - 1)
+
+        # Second request: fetch the random problem
+        async with session.post(
+            LEETCODE_GRAPHQL,
+            json={
+                "query": query,
+                "variables": {
+                    "categorySlug": "all-code-essentials",
+                    "limit": 1,
+                    "skip": random_skip,
+                    "filters": filters,
+                },
+            },
+            headers=HEADERS,
+        ) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"LeetCode API error: {resp.status}")
+            data = await resp.json()
+
+    return data["data"]["problemsetQuestionList"]["questions"][0]

--- a/modules/utils/config.py
+++ b/modules/utils/config.py
@@ -79,6 +79,11 @@ class Config:
             # Superadmin config
             self.SUPERADMIN_USER_ID = os.environ.get("SYS_ADMIN")
 
+            # LeetCode Daily Bot
+            self.LEETCODE_CHANNEL_ID = os.environ.get("LEETCODE_CHANNEL_ID")
+            self.LEETCODE_ROLE_PING = os.environ.get("LEETCODE_ROLE_PING")
+            self.LEETCODE_DAILY_TIME = os.environ.get("LEETCODE_DAILY_TIME", "09:00")
+
         except json.JSONDecodeError as e:
             raise RuntimeError(f"Configuration error: {str(e)}") from e
 

--- a/shared.py
+++ b/shared.py
@@ -111,9 +111,20 @@ def create_auth_bot(loop: asyncio.AbstractEventLoop) -> BotFork:
         from modules.bot.discord_modules.cogs.GameCog import GameCog
         from modules.bot.discord_modules.cogs.HelperCog import HelperCog
 
+        from modules.bot.discord_modules.cogs.LeetCodeCog import LeetCodeCog
+
         auth_bot_instance.add_cog(HelperCog(auth_bot_instance))
         auth_bot_instance.add_cog(GameCog(auth_bot_instance))
-        logger.info("Auth bot cogs (HelperCog, GameCog) registered with BotFork instance.")
+        auth_bot_instance.add_cog(
+            LeetCodeCog(
+                bot=auth_bot_instance,
+                channel_id=int(config.LEETCODE_CHANNEL_ID) if config.LEETCODE_CHANNEL_ID else None,
+                role_ping=int(config.LEETCODE_ROLE_PING) if config.LEETCODE_ROLE_PING else None,
+                daily_time=config.LEETCODE_DAILY_TIME,
+                timezone=config.TIMEZONE,
+            )
+        )
+        logger.info("Auth bot cogs (HelperCog, GameCog, LeetCodeCog) registered with BotFork instance.")
     except Exception as e:
         logger.error(f"Error registering auth bot cogs: {e}", exc_info=True)
     return auth_bot_instance

--- a/shared.py
+++ b/shared.py
@@ -110,16 +110,31 @@ def create_auth_bot(loop: asyncio.AbstractEventLoop) -> BotFork:
     try:
         from modules.bot.discord_modules.cogs.GameCog import GameCog
         from modules.bot.discord_modules.cogs.HelperCog import HelperCog
-
         from modules.bot.discord_modules.cogs.LeetCodeCog import LeetCodeCog
 
         auth_bot_instance.add_cog(HelperCog(auth_bot_instance))
         auth_bot_instance.add_cog(GameCog(auth_bot_instance))
+
+        lc_channel_id: int | None = None
+        lc_role_ping: int | None = None
+        if config.LEETCODE_CHANNEL_ID:
+            try:
+                lc_channel_id = int(config.LEETCODE_CHANNEL_ID)
+            except ValueError:
+                logger.warning(
+                    f"Invalid LEETCODE_CHANNEL_ID '{config.LEETCODE_CHANNEL_ID}', daily task will be skipped"
+                )
+        if config.LEETCODE_ROLE_PING:
+            try:
+                lc_role_ping = int(config.LEETCODE_ROLE_PING)
+            except ValueError:
+                logger.warning(f"Invalid LEETCODE_ROLE_PING '{config.LEETCODE_ROLE_PING}', role ping will be skipped")
+
         auth_bot_instance.add_cog(
             LeetCodeCog(
                 bot=auth_bot_instance,
-                channel_id=int(config.LEETCODE_CHANNEL_ID) if config.LEETCODE_CHANNEL_ID else None,
-                role_ping=int(config.LEETCODE_ROLE_PING) if config.LEETCODE_ROLE_PING else None,
+                channel_id=lc_channel_id,
+                role_ping=lc_role_ping,
                 daily_time=config.LEETCODE_DAILY_TIME,
                 timezone=config.TIMEZONE,
             )


### PR DESCRIPTION
## Summary
- Adds `LeetCodeCog` to the Discord bot with `/daily` and `/random` slash commands
- Scheduled daily post via `discord.ext.tasks` at a configurable time (default 9:00 AM)
- New `modules/bot/discord_modules/utils/leetcode.py` wraps LeetCode's GraphQL API using `aiohttp`
- Three new env vars: `LEETCODE_CHANNEL_ID`, `LEETCODE_ROLE_PING` (optional), `LEETCODE_DAILY_TIME`

## Test plan
- [ ] Set `LEETCODE_CHANNEL_ID` in `.env` and restart the bot
- [ ] Run `/daily` in Discord — should return today's LeetCode challenge embed
- [ ] Run `/random` and `/random Easy` — should return a random problem, filtered correctly
- [ ] Verify daily post fires at the configured time with a ✅ reaction
- [ ] Confirm the bot starts cleanly without `LEETCODE_CHANNEL_ID` set (daily task skipped gracefully)